### PR TITLE
Remove dust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# A directory to put virtual environment stuff in
+venv/
+
+__pycache__/
+
+# Vim swap files
+*.swp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+contourpy==1.3.0
+cycler==0.12.1
+fonttools==4.54.1
+kiwisolver==1.4.7
+matplotlib==3.9.2
+numpy==2.1.2
+packaging==24.1
+pillow==11.0.0
+pyparsing==3.2.0
+python-dateutil==2.9.0.post0
+six==1.16.0


### PR DESCRIPTION
Add a `.gitignore`, and put the dependencies in a `requirements.txt`. I've gotten it to work again on an Ubuntu 24.04 machine! Now to convince Github that this repo is the one to consider canonical, rather than the old version at KeyMe...